### PR TITLE
fix: PyYAMLのビルドエラーを完全に解消

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,19 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential libyaml-dev
+          sudo apt-get install -y build-essential libyaml-dev python3-dev gcc
+
+      # Pythonのセットアップ
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+
+      # pipのアップグレード
+      - name: Upgrade pip
+        run: |
+          python -m pip install --upgrade pip
 
       # Terraformのセットアップ
       - name: Set up Terraform

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+Cython==3.0.8
 boto3==1.38.26
 requests==2.32.3
 line-bot-sdk==3.17.1


### PR DESCRIPTION
- Cythonを依存関係に追加してPyYAMLのビルドサポートを強化
- システムライブラリのインストールを拡充（python3-dev, gccを追加）
- Pythonセットアップを明示的に指定し、pipキャッシュを有効化
- pipを最新バージョンにアップグレード
- Render.comでのデプロイ時のビルド環境を改善
