### PR TITLE
fix: Cythonのビルドエラーを解消

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Cython==3.0.8
+--only-binary :all: Cython==3.0.8
 boto3==1.38.26
 requests==2.32.3
 line-bot-sdk==3.17.1
@@ -20,3 +20,5 @@ itsdangerous==2.1.2
 click==8.1.7
 pydantic==2.11.5
 pydantic-settings==2.2.1
+setuptools>=65.5.1
+wheel>=0.40.0


### PR DESCRIPTION
- Cythonのインストールを事前ビルドwheelパッケージに変更
- ビルドに必要な依存関係を追加
- Render.comでのデプロイエラーを修正

詳細な変更:
- requirements.txtのCython指定を`--only-binary :all: Cython==3.0.8`に変更
- setuptoolsとwheelパッケージを追加してビルド環境を改善

## Issue

close #{IssueNumber}

### 作成内容

- [Issue](https://github.com/KonishiKenji/test-various-tools/issues/{IssueNumber})

## 確認事項

〜特になければ項目自体削除

## 備考


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated dependency installation to prefer binary distributions for Cython.
	- Added minimum version requirements for setuptools and wheel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->