### PR TITLE
fix: update PyYAML version to 6.0.2 to resolve dependency conflict

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ pytest==8.3.5
 pytest-asyncio==0.26.0
 pytest-cov==6.1.1
 python-dotenv==1.1.0
-PyYAML==5.4.1
+PyYAML==6.0.2
 aiohttp==3.12.4
 tenacity==8.5.0
 beautifulsoup4==4.13.4


### PR DESCRIPTION
- Changed PyYAML version from 5.4.1 to 6.0.2 in requirements.txt
- This fixes the deployment error where PyYAML 5.4.1 was not available
- The new version is the latest stable release that is compatible with the project

## Issue

close #{IssueNumber}

### 作成内容

- [Issue](https://github.com/KonishiKenji/test-various-tools/issues/{IssueNumber})

## 確認事項

〜特になければ項目自体削除

## 備考
