### PR TITLE
Fix Railway CLI authentication using config file method

### DIFF
--- a/.github/workflows/deploy-to-railway.yml
+++ b/.github/workflows/deploy-to-railway.yml
@@ -60,11 +60,11 @@ jobs:
         RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
       run: |
         echo "Setting up Railway authentication..."
-        # Railway CLIは環境変数RAILWAY_TOKENを自動的に使用します
-        export RAILWAY_TOKEN="${{ secrets.RAILWAY_TOKEN }}"
+        # Railway CLIの設定ディレクトリを作成
+        mkdir -p ~/.railway
         
-        echo "Verifying Railway authentication..."
-        railway whoami
+        # トークンを設定ファイルに保存
+        echo "{\"token\": \"${{ secrets.RAILWAY_TOKEN }}\"}" > ~/.railway/config.json
         
         echo "Deploying to Railway..."
         railway up --service ${{ secrets.RAILWAY_SERVICE_NAME }} --detach
@@ -82,7 +82,12 @@ jobs:
         RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
       run: |
         echo "Getting deployment URL..."
-        export RAILWAY_TOKEN="${{ secrets.RAILWAY_TOKEN }}"
+        # Railway CLIの設定ディレクトリを作成
+        mkdir -p ~/.railway
+        
+        # トークンを設定ファイルに保存
+        echo "{\"token\": \"${{ secrets.RAILWAY_TOKEN }}\"}" > ~/.railway/config.json
+        
         URL=$(railway status --service ${{ secrets.RAILWAY_SERVICE_NAME }} --json | jq -r '.url')
         echo "deployment_url=$URL" >> $GITHUB_OUTPUT
         echo "Deployment URL: $URL"


### PR DESCRIPTION
- Remove railway whoami command that was causing authentication errors
- Use Railway CLI config file method for authentication
- Create ~/.railway/config.json with token for both deploy and URL steps
- Simplify authentication process to avoid CLI login issues

## Issue

close #{IssueNumber}

### 作成内容

- [Issue](https://github.com/KonishiKenji/test-various-tools/issues/{IssueNumber})

## 確認事項

〜特になければ項目自体削除

## 備考
