### PR TITLE
Fix Railway CLI project specification and service detection

### DIFF
--- a/.github/workflows/deploy-to-railway.yml
+++ b/.github/workflows/deploy-to-railway.yml
@@ -72,9 +72,12 @@ jobs:
         echo "Getting project info..."
         railway status || echo "Status check failed, continuing..."
         
+        echo "Listing available services..."
+        railway service list || echo "Service list failed, continuing..."
+        
         echo "Deploying to Railway..."
-        # プロジェクトを指定してデプロイ
-        railway up --detach --service web
+        # プロジェクトIDを明示的に指定してデプロイ
+        railway up --detach --project price-comparison-app
         
         echo "Deployment initiated successfully!"
 
@@ -96,7 +99,7 @@ jobs:
         rm -rf ~/.railway
         
         echo "Getting service status..."
-        URL=$(railway status --service web --json | jq -r '.url // .domain // "https://your-app.railway.app"')
+        URL=$(railway status --project price-comparison-app --json | jq -r '.url // .domain // "https://your-app.railway.app"')
         echo "deployment_url=$URL" >> $GITHUB_OUTPUT
         echo "Deployment URL: $URL"
 


### PR DESCRIPTION
- Add service list command to debug available services
- Remove service name specification to use default project service
- Add explicit project ID specification with --project flag
- Improve error handling for service detection
- Update URL retrieval to use project-specific status check

## Issue

close #{IssueNumber}

### 作成内容

- [Issue](https://github.com/KonishiKenji/test-various-tools/issues/{IssueNumber})

## 確認事項

〜特になければ項目自体削除

## 備考
