### PR TITLE
fix: replace .filter() with .where() in Firestore queries

### DIFF
--- a/scripts/scrape_prices.py
+++ b/scripts/scrape_prices.py
@@ -285,8 +285,8 @@ class PriceScraper:
             # 既存のドキュメントを検索して更新、または新規作成
             query = (
                 self.db.collection('kaitori_prices')
-                .filter('series', '==', data["series"])
-                .filter('capacity', '==', data["capacity"])
+                .where('series', '==', data["series"])
+                .where('capacity', '==', data["capacity"])
             )
             docs = query.stream()
             
@@ -332,7 +332,7 @@ class PriceScraper:
             # 2週間以上前のデータを検索
             query = (
                 self.db.collection('price_history')
-                .filter('timestamp', '<', two_weeks_ago)
+                .where('timestamp', '<', two_weeks_ago)
             )
             
             docs = query.stream()


### PR DESCRIPTION
- Fix 'CollectionReference' object has no attribute 'filter' error
- Replace .filter() with .where() in save_to_firestore method
- Replace .filter() with .where() in delete_old_data method
- Ensure compatibility with google-cloud-firestore==2.18.0

## Issue

close #{IssueNumber}

### 作成内容

- [Issue](https://github.com/KonishiKenji/test-various-tools/issues/{IssueNumber})

## 確認事項

〜特になければ項目自体削除

## 備考
