### PR TITLE
fix: Railway CI authentication and deployment commands

### DIFF
--- a/.github/workflows/deploy-to-railway.yml
+++ b/.github/workflows/deploy-to-railway.yml
@@ -69,17 +69,19 @@ jobs:
         rm -rf ~/.railway
         
         echo "Testing Railway authentication..."
-        echo "$RAILWAY_TOKEN" | railway login || echo "Login failed, continuing..."
+        # CI環境での認証方法
+        mkdir -p ~/.railway
+        echo "$RAILWAY_TOKEN" > ~/.railway/token.json
         
         echo "Getting project info..."
         railway status || echo "Status check failed, continuing..."
         
         echo "Listing services to identify correct service name..."
-        railway service list --json || echo "Service list failed, trying default service..."
+        railway service || echo "Service command failed, trying default service..."
         
         echo "Deploying to Railway..."
         # サービス名を明示的に指定してデプロイ
-        railway up --detach --service price-comparison-app
+        railway up --detach
         
         echo "Deployment initiated successfully!"
 
@@ -100,11 +102,13 @@ jobs:
         # Railway CLIの設定ディレクトリを完全にクリア
         rm -rf ~/.railway
         
-        echo "Logging in to Railway..."
-        echo "$RAILWAY_TOKEN" | railway login || echo "Login failed, continuing..."
+        echo "Setting up Railway authentication..."
+        # CI環境での認証方法
+        mkdir -p ~/.railway
+        echo "$RAILWAY_TOKEN" > ~/.railway/token.json
         
         echo "Getting service status..."
-        URL=$(railway status --service price-comparison-app --json | jq -r '.url // .domain // "https://your-app.railway.app"')
+        URL=$(railway status --json | jq -r '.url // .domain // "https://your-app.railway.app"')
         echo "deployment_url=$URL" >> $GITHUB_OUTPUT
         echo "Deployment URL: $URL"
 


### PR DESCRIPTION
- Fix CI authentication by creating token.json file instead of interactive login
- Remove invalid --json flag from railway service command
- Simplify railway up command by removing service specification
- Apply same fixes to URL retrieval section
- Use proper CI environment authentication method

## Issue

close #{IssueNumber}

### 作成内容

- [Issue](https://github.com/KonishiKenji/test-various-tools/issues/{IssueNumber})

## 確認事項

〜特になければ項目自体削除

## 備考
