### PR TITLE
fix: Railway service specification and non-interactive commands

### DIFF
--- a/.github/workflows/deploy-to-railway.yml
+++ b/.github/workflows/deploy-to-railway.yml
@@ -77,11 +77,11 @@ jobs:
         railway status || echo "Status check failed, continuing..."
         
         echo "Listing services to identify correct service name..."
-        railway service || echo "Service command failed, trying default service..."
+        railway service list --json || echo "Service list failed, trying default service..."
         
         echo "Deploying to Railway..."
         # サービス名を明示的に指定してデプロイ
-        railway up --detach
+        railway up --detach --service web
         
         echo "Deployment initiated successfully!"
 
@@ -108,7 +108,7 @@ jobs:
         echo "$RAILWAY_TOKEN" > ~/.railway/token.json
         
         echo "Getting service status..."
-        URL=$(railway status --json | jq -r '.url // .domain // "https://your-app.railway.app"')
+        URL=$(railway status --service web --json | jq -r '.url // .domain // "https://your-app.railway.app"')
         echo "deployment_url=$URL" >> $GITHUB_OUTPUT
         echo "Deployment URL: $URL"
 


### PR DESCRIPTION
- Fix TTY error by using 'railway service list --json' instead of interactive 'railway service'
- Add '--service web' flag to 'railway up' command to specify target service
- Add '--service web' flag to 'railway status' command in URL retrieval
- Resolve 'Multiple services found' error by explicitly specifying service

## Issue

close #{IssueNumber}

### 作成内容

- [Issue](https://github.com/KonishiKenji/test-various-tools/issues/{IssueNumber})

## 確認事項

〜特になければ項目自体削除

## 備考
