### PR TITLE
fix: Railway service discovery and fallback deployment strategy

### DIFF
--- a/.github/workflows/deploy-to-railway.yml
+++ b/.github/workflows/deploy-to-railway.yml
@@ -77,11 +77,14 @@ jobs:
         railway status || echo "Status check failed, continuing..."
         
         echo "Listing services to identify correct service name..."
-        railway service list --json || echo "Service list failed, trying default service..."
+        railway service list || echo "Service list failed, trying default service..."
         
         echo "Deploying to Railway..."
-        # サービス名を明示的に指定してデプロイ
-        railway up --detach --service web
+        # 複数のサービス名を試行
+        railway up --detach --service web || \
+        railway up --detach --service price-comparison-app || \
+        railway up --detach --service app || \
+        railway up --detach
         
         echo "Deployment initiated successfully!"
 
@@ -108,7 +111,13 @@ jobs:
         echo "$RAILWAY_TOKEN" > ~/.railway/token.json
         
         echo "Getting service status..."
-        URL=$(railway status --service web --json | jq -r '.url // .domain // "https://your-app.railway.app"')
+        # 複数のサービス名を試行してURLを取得
+        URL=$(railway status --service web 2>/dev/null | grep -o 'https://[^[:space:]]*' | head -1) || \
+        URL=$(railway status --service price-comparison-app 2>/dev/null | grep -o 'https://[^[:space:]]*' | head -1) || \
+        URL=$(railway status --service app 2>/dev/null | grep -o 'https://[^[:space:]]*' | head -1) || \
+        URL=$(railway status 2>/dev/null | grep -o 'https://[^[:space:]]*' | head -1) || \
+        URL="https://your-app.railway.app"
+        
         echo "deployment_url=$URL" >> $GITHUB_OUTPUT
         echo "Deployment URL: $URL"
 


### PR DESCRIPTION
- Remove invalid --json flag from railway service list command
- Implement fallback strategy for service deployment with multiple service names
- Try web, price-comparison-app, app, and default service names
- Update URL retrieval to use grep-based parsing instead of JSON
- Add error handling with 2>/dev/null to suppress error messages

## Issue

close #{IssueNumber}

### 作成内容

- [Issue](https://github.com/KonishiKenji/test-various-tools/issues/{IssueNumber})

## 確認事項

〜特になければ項目自体削除

## 備考
