### PR TITLE
fix: Railway起動コマンド問題を解決

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: cd backend && python app.py 

--- a/railway.json
+++ b/railway.json
@@ -5,7 +5,6 @@
     "buildCommand": "chmod +x backend/build-and-copy.sh && ./backend/build-and-copy.sh"
   },
   "deploy": {
-    "startCommand": "python backend/app.py",
     "healthcheckPath": "/health",
     "healthcheckTimeout": 300,
     "restartPolicyType": "ON_FAILURE",


### PR DESCRIPTION
- Procfileを作成して起動コマンドを明示的に指定
- railway.jsonからstartCommandを削除（Procfileに委ねる）
- cd backend && python app.pyで確実にFlaskアプリを起動

## Issue

close #{IssueNumber}

### 作成内容

- [Issue](https://github.com/KonishiKenji/test-various-tools/issues/{IssueNumber})

## 確認事項

〜特になければ項目自体削除

## 備考
