### PR TITLE
Fix Nixpacks npm undefined error

### DIFF
--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,27 +1,14 @@
 [phases.setup]
-nixPkgs = ["python3", "gcc", "nodejs_18", "npm"]
+nixPkgs = ["python3", "nodejs"]
 
 [phases.install]
-cmds = [
-  "echo '=== INSTALL PHASE ==='",
-  "echo 'Current directory:' && pwd",
-  "echo 'Directory contents:' && ls -la",
-  "echo 'Installing Python dependencies...'",
-  "pip install -r backend/requirements.txt"
-]
+cmds = ["pip install -r backend/requirements.txt"]
 
 [phases.build]
-cmds = [
-  "echo '=== BUILD PHASE ==='",
-  "echo 'Current directory:' && pwd",
-  "echo 'Directory contents:' && ls -la",
-  "echo 'Building Next.js frontend...'",
-  "chmod +x backend/build-and-copy.sh",
-  "timeout 600 backend/build-and-copy.sh"
-]
+cmds = ["chmod +x backend/build-and-copy.sh", "backend/build-and-copy.sh"]
 
 [start]
-cmd = "echo '=== START PHASE ===' && echo 'Current directory:' && pwd && echo 'Directory contents:' && ls -la && echo 'Starting Flask app...' && python backend/app.py"
+cmd = "python backend/app.py"
 
 [variables]
 NODE_ENV = "production"


### PR DESCRIPTION
- Remove 'npm' from nixPkgs (included with nodejs)
- Simplify nixpacks.toml configuration
- Use 'nodejs' instead of 'nodejs_18' for better compatibility
- Remove debug logging to reduce complexity

## Issue

close #{IssueNumber}

### 作成内容

- [Issue](https://github.com/KonishiKenji/test-various-tools/issues/{IssueNumber})

## 確認事項

〜特になければ項目自体削除

## 備考
