### PR TITLE
Fix Nixpacks pip command not found error

### DIFF
--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -2,10 +2,19 @@
 nixPkgs = ["python3", "nodejs"]
 
 [phases.install]
-cmds = ["pip install -r backend/requirements.txt"]
+cmds = [
+  "python3 --version",
+  "python3 -m pip --version",
+  "python3 -m pip install -r backend/requirements.txt"
+]
 
 [phases.build]
-cmds = ["chmod +x backend/build-and-copy.sh", "backend/build-and-copy.sh"]
+cmds = [
+  "node --version",
+  "npm --version",
+  "chmod +x backend/build-and-copy.sh",
+  "backend/build-and-copy.sh"
+]
 
 [start]
 cmd = "python backend/app.py"

--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,17 +1,15 @@
 [phases.setup]
-nixPkgs = ["python3", "nodejs"]
+nixPkgs = ["python3", "nodejs", "curl"]
 
 [phases.install]
 cmds = [
-  "python3 --version",
-  "python3 -m pip --version",
-  "python3 -m pip install -r backend/requirements.txt"
+  "curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py",
+  "python3 get-pip.py --user",
+  "python3 -m pip install --user -r backend/requirements.txt"
 ]
 
 [phases.build]
 cmds = [
-  "node --version",
-  "npm --version",
   "chmod +x backend/build-and-copy.sh",
   "backend/build-and-copy.sh"
 ]


### PR DESCRIPTION
- Use 'python3 -m pip' instead of 'pip' for better compatibility
- Add version checks for Python and Node.js to debug installation
- Add npm version check to ensure Node.js tools are available
- Improve error diagnostics with version information

## Issue

close #{IssueNumber}

### 作成内容

- [Issue](https://github.com/KonishiKenji/test-various-tools/issues/{IssueNumber})

## 確認事項

〜特になければ項目自体削除

## 備考


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved installation process for Python dependencies to enhance reliability during setup. No impact on application features or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->