### PR TITLE
Fix Nixpacks curl network issue and improve pip installation

### DIFF
--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,11 +1,11 @@
 [phases.setup]
-nixPkgs = ["python3", "nodejs", "curl"]
+nixPkgs = ["python3", "nodejs", "python3Packages.setuptools"]
 
 [phases.install]
 cmds = [
-  "curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py",
-  "python3 get-pip.py --user",
-  "python3 -m pip install --user -r backend/requirements.txt"
+  "python3 -m ensurepip --upgrade",
+  "python3 -m pip install --upgrade pip setuptools wheel",
+  "python3 -m pip install -r backend/requirements.txt"
 ]
 
 [phases.build]


### PR DESCRIPTION
- Remove curl dependency to avoid network connectivity issues
- Use python3Packages.setuptools for better Python package management
- Use ensurepip --upgrade for reliable pip installation
- Add setuptools and wheel upgrade for better package compatibility
- Simplify build process to avoid network dependencies

## Issue

close #{IssueNumber}

### 作成内容

- [Issue](https://github.com/KonishiKenji/test-various-tools/issues/{IssueNumber})

## 確認事項

〜特になければ項目自体削除

## 備考
