### PR TITLE
fix: deploy get_price_history Cloud Function and add Firestore index

### DIFF
--- a/docs/firestore.indexes.json
+++ b/docs/firestore.indexes.json
@@ -1,4 +1,23 @@
 {
-  "indexes": [],
+  "indexes": [
+    {
+      "collectionGroup": "price_history",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "series",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "capacity",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "date",
+          "order": "ASCENDING"
+        }
+      ]
+    }
+  ],
   "fieldOverrides": []
 }


### PR DESCRIPTION
- Deploy get_price_history Cloud Function to asia-northeast1
- Add composite index for price_history collection (series, capacity, date)
- Fix 404 error for get_price_history endpoint
- Ensure proper Firestore query performance

## Issue

close #{IssueNumber}

### 作成内容

- [Issue](https://github.com/KonishiKenji/test-various-tools/issues/{IssueNumber})

## 確認事項

〜特になければ項目自体削除

## 備考
