### PR TITLE
Fix price table display issue

### DIFF
--- a/frontend/src/components/PriceComparisonTable.tsx
+++ b/frontend/src/components/PriceComparisonTable.tsx
@@ -177,7 +177,7 @@ export const PriceComparisonTable = memo(function PriceComparisonTable({
                   {row.capacity}
                 </td>
                 <td className='px-6 py-4 whitespace-nowrap text-sm text-gray-900 text-right'>
-                  {formatPrice(row.official_price)}
+                  {row.official_price > 0 ? formatPrice(row.official_price) : 'データなし'}
                 </td>
                 <td className='px-6 py-4 whitespace-nowrap text-sm text-gray-900 text-right'>
                   {formatPrice(row.kaitori_price)}
@@ -185,12 +185,12 @@ export const PriceComparisonTable = memo(function PriceComparisonTable({
                 <td
                   className={`px-6 py-4 whitespace-nowrap text-sm text-right ${diffColor}`}
                 >
-                  {formatPrice(row.price_diff)}
+                  {row.official_price > 0 ? formatPrice(row.price_diff) : '-'}
                 </td>
                 <td
                   className={`px-6 py-4 whitespace-nowrap text-sm text-right ${diffColor}`}
                 >
-                  {formatPercentage(row.price_diff, row.official_price)}
+                  {row.official_price > 0 ? formatPercentage(row.price_diff, row.official_price) : '-'}
                 </td>
                 {showRakutenColumns && (
                   <>
@@ -199,14 +199,14 @@ export const PriceComparisonTable = memo(function PriceComparisonTable({
                         row.rakuten_diff
                       )}`}
                     >
-                      {formatPrice(row.rakuten_diff)}
+                      {row.official_price > 0 ? formatPrice(row.rakuten_diff) : '-'}
                     </td>
                     <td
                       className={`px-6 py-4 whitespace-nowrap text-sm text-right ${getPriceDiffColor(
                         row.rakuten_diff
                       )}`}
                     >
-                      {formatPercentage(row.rakuten_diff, row.kaitori_price)}
+                      {row.official_price > 0 ? formatPercentage(row.rakuten_diff, row.kaitori_price) : '-'}
                     </td>
                   </>
                 )}

--- a/functions/get_prices/main.py
+++ b/functions/get_prices/main.py
@@ -15,16 +15,93 @@ def get_prices(request):
     
     db = firestore.Client()
     series = request.args.get('series')
-    prices_ref = db.collection('kaitori_prices')
-    query = prices_ref
+    
+    # 買取価格データを取得
+    kaitori_prices_ref = db.collection('kaitori_prices')
+    kaitori_query = kaitori_prices_ref
     if series:
-        query = query.where('series', '==', series)
-    docs = query.stream()
-    result = []
-    for doc in docs:
+        kaitori_query = kaitori_query.where('series', '==', series)
+    kaitori_docs = kaitori_query.stream()
+    
+    # 公式価格データを取得
+    official_prices_ref = db.collection('official_prices')
+    if series:
+        # シリーズ名でドキュメントIDを検索
+        doc_ref = official_prices_ref.document(series)
+        doc_snapshot = doc_ref.get()
+        print(f"Document exists: {doc_snapshot.exists}")
+        if doc_snapshot.exists:
+            print(f"Document data: {doc_snapshot.to_dict()}")
+        official_docs = [doc_snapshot] if doc_snapshot.exists else []
+    else:
+        official_docs = official_prices_ref.stream()
+    
+    # データを整理
+    kaitori_data = {}
+    for doc in kaitori_docs:
         data = doc.to_dict()
-        data['id'] = doc.id
-        result.append(data)
+        series_name = data.get('series')
+        if series_name not in kaitori_data:
+            kaitori_data[series_name] = {}
+        
+        capacity = data.get('capacity')
+        kaitori_data[series_name][capacity] = {
+            'kaitori_price_min': data.get('kaitori_price_min', 0),
+            'kaitori_price_max': data.get('kaitori_price_max', 0),
+            'colors': data.get('colors', {})
+        }
+    
+    official_data = {}
+    for doc in official_docs:
+        data = doc.to_dict()
+        series_name = doc.id  # ドキュメントIDがシリーズ名
+        if series_name not in official_data:
+            official_data[series_name] = {}
+        
+        # データ構造: {'price': {'256GB': {'colors': {...}}}}
+        price_data = data.get('price', {})
+        for capacity, capacity_data in price_data.items():
+            # 各容量の色の価格から平均価格を計算
+            colors = capacity_data.get('colors', {})
+            if colors:
+                avg_price = sum(colors.values()) / len(colors)
+                official_data[series_name][capacity] = {
+                    'official_price': int(avg_price)
+                }
+    
+    # デバッグ用ログ
+    print(f"Official data for {series}: {official_data}")
+    
+    # フロントエンドが期待する形式に変換
+    result = {}
+    for series_name in kaitori_data:
+        if series_name not in result:
+            result[series_name] = {
+                'series': series_name,
+                'prices': {}
+            }
+        
+        for capacity in kaitori_data[series_name]:
+            kaitori_info = kaitori_data[series_name][capacity]
+            official_info = official_data.get(series_name, {}).get(capacity, {})
+            
+            official_price = official_info.get('official_price', 0)
+            kaitori_price = kaitori_info.get('kaitori_price_max', 0)  # 最大買取価格を使用
+            price_diff = kaitori_price - official_price
+            rakuten_diff = kaitori_price - (official_price * 0.9)
+            
+            result[series_name]['prices'][capacity] = {
+                'official_price': official_price,
+                'kaitori_price': kaitori_price,
+                'price_diff': price_diff,
+                'rakuten_diff': rakuten_diff
+            }
+    
+    # シリーズ指定の場合は単一オブジェクトを返す
+    if series and series in result:
+        response_data = result[series]
+    else:
+        response_data = result
     
     # CORSヘッダーを含むヘッダーを設定
     headers = {
@@ -32,4 +109,4 @@ def get_prices(request):
         'Cache-Control': 'public, max-age=300',
         **get_cors_headers()
     }
-    return (json.dumps(result, default=str), 200, headers) 
+    return (json.dumps(response_data, default=str), 200, headers) 


### PR DESCRIPTION
## 概要
価格表が表示されない問題を修正しました。

## 修正内容
-  APIのデータ構造を修正してフロントエンドが期待する形式に合わせました
- 公式価格が0の場合の表示を改善（「データなし」と表示）
- 価格差額と差額率の計算で公式価格が0の場合は「-」を表示
- 楽天錬金列でも同様の処理を追加

## 技術的詳細
- APIレスポンス形式をに統一
- フロントエンドで公式価格が0の場合の適切な表示処理を追加
- データ構造の不整合による表示問題を解決

## テスト
- フロントエンドのビルドが正常に完了
- APIレスポンスが正しい形式で返されることを確認
- 公式価格が0の場合でも適切に表示されることを確認